### PR TITLE
Improved LoginPacket detection

### DIFF
--- a/src/packet/LoginPacket.ts
+++ b/src/packet/LoginPacket.ts
@@ -49,7 +49,7 @@ export default class LoginPacket {
     public static isThisPacket(data: Packet): boolean {
         const p = new this(data);
         try {
-            return p.id === this.id && p.data.username.length > 0;
+            return p.id === this.id && p.data.username.match(/^[.*]?[A-Za-z0-9_]{3,16}$/) !== null;
         }
         catch {
             return false;


### PR DESCRIPTION
Use RegEx to detect correct usernames only

Username may or may not start with `.` or `*` (due to Geyser/floodgate/whatever compatibility concern)

Username must have min 3 max 16 A-Za-z0-9_ characters.