### PR TITLE
Autogenerate documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,3 +21,4 @@ jobs:
           message: "chore: update documentation"
           auth_token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.repository }}
+          from: ${{ github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,4 +21,3 @@ jobs:
           message: "chore: update documentation"
           auth_token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.repository }}
-          from: ${{ github.head_ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,4 +21,4 @@ jobs:
           message: "chore: update documentation"
           auth_token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.repository }}
-          from: ${{ github.ref }}
+          from: ${{ github.head_ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,9 @@ name: Generate docs
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
-    branches: [main]
+    branches: [ main ]
 
 jobs:
   generate-docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,3 +20,4 @@ jobs:
           docs_folder: docs
           message: "chore: update documentation"
           auth_token: ${{ secrets.GITHUB_TOKEN }}
+          repo: ${{ github.repository }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,3 +21,4 @@ jobs:
           message: "chore: update documentation"
           auth_token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.repository }}
+          name: ${{ github.actor }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Generate docs
 
 on:
   push:
@@ -8,24 +8,10 @@ on:
 
 jobs:
   generate-docs:
-    name: Build and upload
+    name: Generate docs
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-
-      - name: Set up Node 18
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Generate docs with typedoc
-        run: npm run docs
-
       - name: Sync to Github Wiki
         uses: arciera/github-wiki-sync@main
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   generate-docs:
     name: Generate docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  package-and-upload:
+  generate-docs:
     name: Build and upload
     runs-on: ubuntu-latest
 
@@ -27,12 +27,9 @@ jobs:
         run: npm run docs
 
       - name: Sync to Github Wiki
-        uses: joeizzard/action-wiki-sync@master
+        uses: arciera/github-wiki-sync@main
 
         with:
-          username: ${{ secrets.GITHUB_ACTOR }}
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-          wiki_folder: docs
-          commit_username: ${{ secrets.GITHUB_ACTOR }}
-          commit_email: ${{ secrets.GITHUB_ACTOR }}@users.noreply.github.com
-          commit_message: "Synced wiki from main branch"
+          build_script: docs
+          docs_folder: docs
+          message: "chore: update documentation"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  package-and-upload:
+    name: Build and upload
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Generate docs with typedoc
+        run: npm run docs
+
+      - name: Sync to Github Wiki
+        uses: joeizzard/action-wiki-sync@master
+
+        with:
+          username: ${{ secrets.GITHUB_ACTOR }}
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+          wiki_folder: docs
+          commit_user_name: ${{ secrets.GITHUB_ACTOR }}
+          commit_user_email: ${{ secrets.GITHUB_ACTOR }}@users.noreply.github.com
+          commit_message: "Synced wiki from main branch"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,3 +19,4 @@ jobs:
           build_script: docs
           docs_folder: docs
           message: "chore: update documentation"
+          auth_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Sync to Github Wiki
+      - name: Sync the Github Wiki
         uses: arciera/github-wiki-sync@main
 
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
+      - name: Set up Node 18
         uses: actions/setup-node@v3
         with:
           node-version: 18.x

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,6 @@ jobs:
           username: ${{ secrets.GITHUB_ACTOR }}
           access_token: ${{ secrets.GITHUB_TOKEN }}
           wiki_folder: docs
-          commit_user_name: ${{ secrets.GITHUB_ACTOR }}
-          commit_user_email: ${{ secrets.GITHUB_ACTOR }}@users.noreply.github.com
+          commit_username: ${{ secrets.GITHUB_ACTOR }}
+          commit_email: ${{ secrets.GITHUB_ACTOR }}@users.noreply.github.com
           commit_message: "Synced wiki from main branch"

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dist
 *.js
 *.d.ts
 .idea
+
+# documentation
+docs/

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "devDependencies": {
         "@types/node": "^20.4.9",
         "@vercel/ncc": "^0.36.1",
+        "typedoc": "^0.24.8",
+        "typedoc-github-wiki-theme": "^1.1.0",
+        "typedoc-plugin-markdown": "^3.15.4",
         "typescript": "^5.1.6"
       }
     },
@@ -29,6 +32,166 @@
         "ncc": "dist/ncc/cli.js"
       }
     },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
+      "dev": true
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "node_modules/shiki": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.3.tgz",
+      "integrity": "sha512-U3S/a+b0KS+UkTyMjoNojvTgrBHjgp7L6ovhFVZsXmBGnVdQ4K4U9oK0z63w538S91ATngv1vXigHCSWOwnr+g==",
+      "dev": true,
+      "dependencies": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typedoc": {
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.8.tgz",
+      "integrity": "sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.0",
+        "shiki": "^0.14.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 14.14"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x"
+      }
+    },
+    "node_modules/typedoc-github-wiki-theme": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/typedoc-github-wiki-theme/-/typedoc-github-wiki-theme-1.1.0.tgz",
+      "integrity": "sha512-VyFmz8ZV2j/qEsCjD5EtR6FgZsCoy64Zr6SS9kCTcq7zx69Cx4UJBx8Ga/naxqs08TDggE6myIfODY6awwAGcA==",
+      "dev": true,
+      "peerDependencies": {
+        "typedoc": ">=0.24.0",
+        "typedoc-plugin-markdown": ">=3.15.0"
+      }
+    },
+    "node_modules/typedoc-plugin-markdown": {
+      "version": "3.15.4",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.15.4.tgz",
+      "integrity": "sha512-KpjFL/NDrQAbY147oIoOgob2vAdEchsMcTVd6+e6H2lC1l5xhi48bhP/fMJI7qYQ8th5nubervgqw51z7gY66A==",
+      "dev": true,
+      "dependencies": {
+        "handlebars": "^4.7.7"
+      },
+      "peerDependencies": {
+        "typedoc": ">=0.24.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
@@ -41,6 +204,37 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "build:start": "npm run build && npm run start",
     "bundle": "ncc build ./index.ts -o build -m",
-    "docs": "typedoc --out docs ./index.ts",
+    "docs": "typedoc",
     "start": "node dist/index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc",
     "build:start": "npm run build && npm run start",
     "bundle": "ncc build ./index.ts -o build -m",
+    "docs": "typedoc --out docs ./index.ts",
     "start": "node dist/index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -16,7 +17,10 @@
   "license": "GNU GPLv3",
   "devDependencies": {
     "@types/node": "^20.4.9",
-    "typescript": "^5.1.6",
-    "@vercel/ncc": "^0.36.1"
+    "@vercel/ncc": "^0.36.1",
+    "typedoc": "^0.24.8",
+    "typedoc-github-wiki-theme": "^1.1.0",
+    "typedoc-plugin-markdown": "^3.15.4",
+    "typescript": "^5.1.6"
   }
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,13 +1,13 @@
 {
     "$schema": "https://typedoc.org/schema.json",
     "entryPoints": [
-        "./**/*.ts"
+        "./src/*.ts"
     ],
     "plugin": [
-        "typedoc-plugin-markdown",
-        "typedoc-github-wiki-theme"
+        // "typedoc-plugin-markdown",
+        // "typedoc-github-wiki-theme"
     ],
     "out": "./docs",
     "name": "arciera/server",
-    "theme": "github-wiki",
+    // "theme": "github-wiki",
 }   

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://typedoc.org/schema.json",
+    "entryPoints": [
+        "./**/*.ts"
+    ],
+    "plugin": [
+        "typedoc-plugin-markdown",
+        "typedoc-github-wiki-theme"
+    ],
+    "out": "./docs",
+    "name": "arciera/server",
+    "theme": "github-wiki",
+}   

--- a/typedoc.json
+++ b/typedoc.json
@@ -4,10 +4,10 @@
         "./src/*.ts"
     ],
     "plugin": [
-        // "typedoc-plugin-markdown",
-        // "typedoc-github-wiki-theme"
+        "typedoc-plugin-markdown",
+        "typedoc-github-wiki-theme"
     ],
     "out": "./docs",
     "name": "arciera/server",
-    // "theme": "github-wiki",
+    "theme": "github-wiki",
 }   


### PR DESCRIPTION
This commit adds typedoc documentation generation that also automatically on push to main, updates the github wiki with fresh markdown.

pros:
we do not need to documentation ourselves

cons:
~~it overwrites the entire wiki, meaning that it's basically read-only~~
does not anymore, it just updates all other files